### PR TITLE
Remove Eventbox link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,5 @@ To change kernel, do this:
 #### Sources:
 
 * https://huggingface.co/docs/sagemaker/main
-* https://www.eventbox.dev/published/lesson/amazon-sagemaker-nlp-workshop/
 * https://github.com/huggingface/notebooks/tree/master/sagemaker
 


### PR DESCRIPTION
This change removes a reference to a deprecated tool.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
